### PR TITLE
FIX summary tab note #23: mb_strlen() instead of count()

### DIFF
--- a/CRM/Gdprx/Page/SummaryTab.php
+++ b/CRM/Gdprx/Page/SummaryTab.php
@@ -69,7 +69,7 @@ class CRM_Gdprx_Page_SummaryTab extends CRM_Core_Page {
         'record_terms_name'  => $data->record_terms_name,
         'record_terms_full'  => $data->record_terms_full,
         'record_terms_id'    => $data->record_terms_id,
-        'record_note_short'  => count($data->record_note) > 16 ? (substr($data->record_note, 0, 13) . '...') : $data->record_note,
+        'record_note_short'  => mb_strlen($data->record_note) > 16 ? (substr($data->record_note, 0, 13) . '...') : $data->record_note,
         'record_note'        => $data->record_note,
       );
     }


### PR DESCRIPTION
The function `run()` in `CRM/Gdprx/Page/SummaryTab.php`  includes a check if the `$data->record_note` is too long to be fully displayed.
This check wrongly uses `count()` instead of `mb_strlen()` resulting in "Unable to reach the server".

The patch just changes `count()` to `mb_strlen()`.