### PR TITLE
Summary tab: Escape with htmlspecialchars().

### DIFF
--- a/CRM/Gdprx/Page/SummaryTab.php
+++ b/CRM/Gdprx/Page/SummaryTab.php
@@ -67,10 +67,10 @@ class CRM_Gdprx_Page_SummaryTab extends CRM_Core_Page {
         'record_source'      => $data->record_source,
         'record_type'        => $data->record_type,
         'record_terms_name'  => $data->record_terms_name,
-        'record_terms_full'  => $data->record_terms_full,
+        'record_terms_full'  => htmlspecialchars($data->record_terms_full),
         'record_terms_id'    => $data->record_terms_id,
         'record_note_short'  => mb_strlen($data->record_note) > 16 ? (substr($data->record_note, 0, 13) . '...') : $data->record_note,
-        'record_note'        => $data->record_note,
+        'record_note'        => htmlspecialchars($data->record_note),
       );
     }
 


### PR DESCRIPTION
See #25 .

I am escaping both record_note and record_terms with htmlspecialchars().
