### PR TITLE
FIX lost dates

### DIFF
--- a/CRM/Gdprx/Form/ConsentEdit.php
+++ b/CRM/Gdprx/Form/ConsentEdit.php
@@ -141,8 +141,8 @@ class CRM_Gdprx_Form_ConsentEdit extends CRM_Core_Form {
     if ($this->record_id > 0) {
       // there is already a record
       $data = CRM_Gdprx_Consent::getRecord($this->record_id);
-      list($date_values['consent_ui_date'], $date_values['consent_ui_date_time']) = CRM_Utils_Date::setDateDefaults(date('Y-m-d H:i:s', strtotime($data['consent_date'])), 'activityDateTime');
-      list($date_values['consent_ui_expiry_date'], $date_values['consent_ui_expiry_date_time']) = CRM_Utils_Date::setDateDefaults(date('Y-m-d H:i:s', strtotime($data['consent_ui_expiry_date'])), 'activityDateTime');
+      $date_values['consent_ui_date'] = date('Y-m-d H:i:s', strtotime($data['consent_date']));
+      $date_values['consent_ui_expiry_date'] = date('Y-m-d H:i:s', strtotime($data['consent_expiry_date']));
 
       $this->setDefaults(array(
         'consent_ui_category'    => $data['consent_category'],


### PR DESCRIPTION
I removed the calls to CRM_Utils_Date::setDateDefaults(), e.g. for start date:
`date('Y-m-d H:i:s', strtotime($data['consent_date'])` ()

Also the assignment to `$date_values['consent_ui_expiry_date']` wrongly used 
`$data['consent_ui_expiry_date']` - that should be
`$data['consent_expiry_date']`.

`'consent_ui_date_time'` and `'consent_ui_expiry_date_time'` are not needed, date and time are both set by one `'Y-m-d H:i:s'` formated datetime.

That way date and time are set in the popup form editing an existing consent.   