### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.gdprx/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <requires/>
   <comments>See https://en.wikipedia.org/wiki/General_Data_Protection_Regulation</comments>

--- a/templates/CRM/Gdprx/Form/Settings.tpl
+++ b/templates/CRM/Gdprx/Form/Settings.tpl
@@ -15,12 +15,12 @@
 
 <h3>{ts domain="de.systopia.gdprx"}General Options{/ts}</h3>
 <div class="crm-section">
-  <div class="label">{$form.enforce_record_for_new_contacts.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.gdprx"}Enforce Record{/ts}", {literal}{"id":"id-gdprx-enforce-record","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.enforce_record_for_new_contacts.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.gdprx"}Enforce Record{/ts}", {literal}{"id":"id-gdprx-enforce-record","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.enforce_record_for_new_contacts.html}</div>
   <div class="clear"></div>
 </div>
 <div class="crm-section">
-  <div class="label">{$form.consent_source_default.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.gdprx"}Default Source{/ts}", {literal}{"id":"id-gdprx-default-source","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.consent_source_default.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.gdprx"}Default Source{/ts}", {literal}{"id":"id-gdprx-default-source","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.consent_source_default.html}</div>
   <div class="clear"></div>
 </div>
@@ -53,13 +53,13 @@
 
 <h3>{ts domain="de.systopia.gdprx"}Privacy Settings{/ts}</h3>
 <div class="crm-section">
-  <div class="label">{$form.disable_privacy_edit.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.gdprx"}Disable Editing of Privacy Settings{/ts}", {literal}{"id":"id-gdprx-disable-privacy-edit","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.disable_privacy_edit.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.gdprx"}Disable Editing of Privacy Settings{/ts}", {literal}{"id":"id-gdprx-disable-privacy-edit","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.disable_privacy_edit.html}</div>
   <div class="clear"></div>
 </div>
 
 <div class="crm-section">
-  <div class="label">{$form.default_privacy_settings_enabled.label}&nbsp;<a onclick='CRM.help("{ts domain="de.systopia.gdprx"}Default Privacy Settings{/ts}", {literal}{"id":"id-gdprx-default-privacy","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
+  <div class="label">{$form.default_privacy_settings_enabled.label}&nbsp;<a onclick='CRM.help("{ts escape='htmlattribute' domain="de.systopia.gdprx"}Default Privacy Settings{/ts}", {literal}{"id":"id-gdprx-default-privacy","file":"CRM\/Gdprx\/Form\/Settings"}{/literal}); return false;' href="#" title="{ts escape='htmlattribute' domain="de.systopia.gdprx"}Help{/ts}" class="helpicon">&nbsp;</a></div>
   <div class="content">{$form.default_privacy_settings_enabled.html}</div>
   <div class="clear"></div>
 </div>

--- a/templates/CRM/Gdprx/Page/SummaryTab.tpl
+++ b/templates/CRM/Gdprx/Page/SummaryTab.tpl
@@ -76,7 +76,7 @@
       {/if}
       <td>
         {assign value=$record.record_id var=record_id}
-        <span><a href="{crmURL p='civicrm/gdprx/consent/edit' q="id=$record_id&cid=$contact_id&reset=1"}" class="action-item crm-hover-button crm-popup" title="{ts domain="de.systopia.gdprx"}Edit{/ts}">{ts domain="de.systopia.gdprx"}Edit{/ts}</a></span>
+        <span><a href="{crmURL p='civicrm/gdprx/consent/edit' q="id=$record_id&cid=$contact_id&reset=1"}" class="action-item crm-hover-button crm-popup" title="{ts escape='htmlattribute' domain="de.systopia.gdprx"}Edit{/ts}">{ts domain="de.systopia.gdprx"}Edit{/ts}</a></span>
       </td>
     </tr>
     {/foreach}


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.