### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Gdprx/ConsentUI.php
+++ b/CRM/Gdprx/ConsentUI.php
@@ -135,17 +135,17 @@ class CRM_Gdprx_ConsentUI {
       return;
     }
 
-    $category = CRM_Utils_Array::value( 'consent_ui_category', $fields );
+    $category = $fields ['consent_ui_category'] ?? NULL;
     if (!$category || $category == '0') {
       $errors['consent_ui_category'] = E::ts('Category is mandatory');
     }
 
-    $source = CRM_Utils_Array::value( 'consent_ui_source', $fields );
+    $source = $fields ['consent_ui_source'] ?? NULL;
     if (!$source || $source == '0') {
       $errors['consent_ui_source'] = E::ts('Source is mandatory');
     }
 
-    $contact_origin = CRM_Utils_Array::value( 'consent_ui_note', $fields );
+    $contact_origin = $fields ['consent_ui_note'] ?? NULL;
     if (strlen($contact_origin) > 1024) {
       $errors['consent_ui_note'] = E::ts('Note cannot be more the 1024 characters');
     }
@@ -172,10 +172,10 @@ class CRM_Gdprx_ConsentUI {
                                              $values['consent_ui_category'],
                                              $values['consent_ui_source'],
                                              $values['consent_ui_date'],
-                                             CRM_Utils_Array::value('consent_ui_note', $values),
-                                             CRM_Utils_Array::value('consent_ui_type', $values),
-                                             CRM_Utils_Array::value('consent_ui_terms', $values),
-                                             CRM_Utils_Array::value('consent_ui_expiry_date', $values));
+                                             $values['consent_ui_note'] ?? NULL,
+                                             $values['consent_ui_type'] ?? NULL,
+                                             $values['consent_ui_terms'] ?? NULL,
+                                             $values['consent_ui_expiry_date'] ?? NULL);
     }
   }
 }

--- a/CRM/Gdprx/CustomData.php
+++ b/CRM/Gdprx/CustomData.php
@@ -735,7 +735,7 @@ class CRM_Gdprx_CustomData {
                 return $field_data['value'];
             } else {
                 // unlikely, but worth a shot:
-                return CRM_Utils_Array::value("custom_{$field_id}", $params, NULL);
+                return $params["custom_{$field_id}"] ?? NULL;
             }
         }
         return NULL;
@@ -785,9 +785,9 @@ class CRM_Gdprx_CustomData {
                 'value'           => $value,
                 'type'            => CRM_Utils_Array::value('data_type', $field_specs, 'String'),
                 'custom_field_id' => $field_id,
-                'custom_group_id' => CRM_Utils_Array::value('custom_group_id', $field_specs, NULL),
-                'table_name'      => CRM_Utils_Array::value('table_name', $group_specs, NULL),
-                'column_name'     => CRM_Utils_Array::value('column_name', $field_specs, NULL),
+                'custom_group_id' => $field_specs['custom_group_id'] ?? NULL,
+                'table_name'      => $group_specs['table_name'] ?? NULL,
+                'column_name'     => $field_specs['column_name'] ?? NULL,
                 'is_multiple'     => CRM_Utils_Array::value('is_multiple', $group_specs, 0),
             ];
         } else {

--- a/CRM/Gdprx/Form/ConsentEdit.php
+++ b/CRM/Gdprx/Form/ConsentEdit.php
@@ -187,7 +187,7 @@ class CRM_Gdprx_Form_ConsentEdit extends CRM_Core_Form {
 
 
     // get expiry date
-    $expiry_date = CRM_Utils_Array::value('consent_ui_expiry_date', $values);
+    $expiry_date = $values['consent_ui_expiry_date'] ?? NULL;
 
     if (empty($values['record_id'])) {
       $categories = is_array($values['consent_ui_category']) ? $values['consent_ui_category'] : array($values['consent_ui_category']);
@@ -198,8 +198,8 @@ class CRM_Gdprx_Form_ConsentEdit extends CRM_Core_Form {
             $category,
             $values['consent_ui_source'],
             date('YmdHis', strtotime(CRM_Utils_Date::processDate($values['consent_ui_date'], $values['consent_ui_date_time']))),
-            CRM_Utils_Array::value('consent_ui_note', $values, NULL),
-            CRM_Utils_Array::value('consent_ui_type', $values, NULL),
+            $values['consent_ui_note'] ?? NULL,
+            $values['consent_ui_type'] ?? NULL,
             $terms_id,
             $expiry_date ? date('YmdHis', strtotime(CRM_Utils_Date::processDate($values['consent_ui_expiry_date'], $values['consent_ui_expiry_date_time']))) : NULL);
       }
@@ -211,8 +211,8 @@ class CRM_Gdprx_Form_ConsentEdit extends CRM_Core_Form {
         $values['consent_ui_category'],
         $values['consent_ui_source'],
         date('YmdHis', strtotime(CRM_Utils_Date::processDate($values['consent_ui_date'], $values['consent_ui_date_time']))),
-        CRM_Utils_Array::value('consent_ui_note', $values, NULL),
-        CRM_Utils_Array::value('consent_ui_type', $values, NULL),
+        $values['consent_ui_note'] ?? NULL,
+        $values['consent_ui_type'] ?? NULL,
         $terms_id,
        $expiry_date ? date('YmdHis', strtotime(CRM_Utils_Date::processDate($values['consent_ui_expiry_date'], $values['consent_ui_expiry_date_time']))) : NULL);
     }

--- a/CRM/Gdprx/Form/ConsentTask.php
+++ b/CRM/Gdprx/Form/ConsentTask.php
@@ -147,7 +147,7 @@ class CRM_Gdprx_Form_ConsentTask extends CRM_Contact_Form_Task {
 
 
     // get expiry date
-    $expiry_date = CRM_Utils_Array::value('consent_ui_expiry_date', $values);
+    $expiry_date = $values['consent_ui_expiry_date'] ?? NULL;
 
     // create a new records
     foreach ($this->_contactIds as $contact_id) {
@@ -156,8 +156,8 @@ class CRM_Gdprx_Form_ConsentTask extends CRM_Contact_Form_Task {
         $values['consent_ui_category'],
         $values['consent_ui_source'],
         date('YmdHis', strtotime($values['consent_ui_date'])),
-        CRM_Utils_Array::value('consent_ui_note', $values, NULL),
-        CRM_Utils_Array::value('consent_ui_type', $values, NULL),
+        $values['consent_ui_note'] ?? NULL,
+        $values['consent_ui_type'] ?? NULL,
         $terms_id,
         $expiry_date ? date('YmdHis', strtotime($expiry_date)) : NULL);
     }

--- a/api/v3/ConsentRecord/Create.php
+++ b/api/v3/ConsentRecord/Create.php
@@ -53,8 +53,8 @@ function civicrm_api3_consent_record_create($params) {
     $params['category'],
     $params['source'],
     $date,
-    CRM_Utils_Array::value('note', $params, NULL),
-    CRM_Utils_Array::value('type', $params, NULL),
+    $params['note'] ?? NULL,
+    $params['type'] ?? NULL,
     $terms ? $terms->getID() : NULL,
     $expiry_date);
 }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.